### PR TITLE
blockのリクエストボディをblockUserIdにした

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -147,12 +147,12 @@ paths:
                 userId:
                   type: "string"
                   format: "uuid"
-                favUserId:
+                blockUserId:
                   type: "string"
                   format: "uuid"
             example:
               userId: "cnt14069"
-              favUserId: "cnt14070"
+              blockUserId: "cnt14070"
       responses:
         "200":
           description: "成功"
@@ -170,12 +170,12 @@ paths:
                 userId:
                   type: "string"
                   format: "uuid"
-                favUserId:
+                blockUserId:
                   type: "string"
                   format: "uuid"
             example:
               userId: "cnt14069"
-              favUserId: "cnt14070"
+              blockUserId: "cnt14070"
       responses:
         "200":
           description: "成功"


### PR DESCRIPTION
## 概要
<!-- 関連するIssue-->
<!-- 経緯・背景・どんなことを行うのか-->
ユーザーのブロックとブロック解除のリクエストボディが
userId
favUserIdになっていた

## 実装
<!-- どういうアプローチで変更を行ったか-->
userId
blockUserId
に修正しました

## 備考
<!-- 実装中に発見した仕様など、共有しておきたいこと-->
特になしいい