### PR TITLE
fix:ユーザ情報更新のbodyにimageを追加

### DIFF
--- a/openapi.yml
+++ b/openapi.yml
@@ -52,7 +52,7 @@ paths:
       requestBody:
         required: true
         content:
-          application/json:
+          multipart/form-data:
             schema:
               $ref: "#/components/schemas/updateUserRequest"
       responses:
@@ -98,10 +98,8 @@ paths:
               properties:
                 userId:
                   type: "string"
-                  format: "uuid"
                 favUserId:
                   type: "string"
-                  format: "uuid"
             example:
               userId: "cnt14069"
               favUserId: "cnt14070"
@@ -121,10 +119,8 @@ paths:
               properties:
                 userId:
                   type: "string"
-                  format: "uuid"
                 favUserId:
                   type: "string"
-                  format: "uuid"
             example:
               userId: "cnt14069"
               favUserId: "cnt14070"
@@ -146,10 +142,8 @@ paths:
               properties:
                 userId:
                   type: "string"
-                  format: "uuid"
                 blockUserId:
                   type: "string"
-                  format: "uuid"
             example:
               userId: "cnt14069"
               blockUserId: "cnt14070"
@@ -169,10 +163,8 @@ paths:
               properties:
                 userId:
                   type: "string"
-                  format: "uuid"
                 blockUserId:
                   type: "string"
-                  format: "uuid"
             example:
               userId: "cnt14069"
               blockUserId: "cnt14070"
@@ -422,13 +414,21 @@ components:
         age:
           type: "integer"
         grade:
-          type: "integer"
+          type: "string"
         field:
           type: "string"
         introduction:
           type: "string"
-        iconUrl:
-          type: "string"
+        iconImage:
+            type: string
+            format: binary
+        profileImage:
+            type: string
+            format: binary
+        coverImage:
+            type: string
+            format: binary
+              
     userRelationShip:
       type: "object"
       properties:


### PR DESCRIPTION
### 変更の概要
-  `#/components/schemas/updateUserRequest`に画像データを追加
-  `userId`のformatがuuidになっていた為修正